### PR TITLE
Add gh link to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,3 +53,4 @@ Imports:
     stats
 VignetteBuilder: knitr
 URL: https://openpharma.github.io/beeca/
+BugReports: https://github.com/openpharma/beeca/issues


### PR DESCRIPTION
for discoverability = jump easily from site to repo.https://blog.r-hub.io/2019/12/10/urls/